### PR TITLE
fix: include tailwindcss PostCSS plugin in prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "latest",
     "react-dom": "latest",
     "tailwindcss": "latest",
-    "zod": "latest"
+    "zod": "latest",
+    "@tailwindcss/postcss": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",
@@ -29,7 +30,6 @@
     "@types/react-dom": "latest",
     "eslint": "latest",
     "eslint-config-next": "latest",
-    "@tailwindcss/postcss": "latest",
     "@types/papaparse": "latest",
     "prisma": "latest",
     "tsx": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@prisma/client':
         specifier: latest
         version: 6.15.0(prisma@6.15.0(typescript@5.9.2))(typescript@5.9.2)
+      '@tailwindcss/postcss':
+        specifier: latest
+        version: 4.1.12
       autoprefixer:
         specifier: latest
         version: 10.4.21(postcss@8.5.6)
@@ -39,9 +42,6 @@ importers:
         specifier: latest
         version: 4.1.5
     devDependencies:
-      '@tailwindcss/postcss':
-        specifier: latest
-        version: 4.1.12
       '@types/node':
         specifier: latest
         version: 24.3.0


### PR DESCRIPTION
## Summary
- move `@tailwindcss/postcss` from devDependencies to dependencies so Next.js build can find plugin

## Testing
- `pnpm install`
- `pnpm db:push`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b83ed6604c8328b3647f7f58860339