### PR TITLE
fix: rely on Next default PostCSS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ App web (Next.js + Prisma + Tailwind) para **unificar señales** de múltiples h
    ```
    Abre http://localhost:3000
 
+> Este proyecto usa la configuración PostCSS por defecto de Next.js con Tailwind CSS, por lo que no se requiere un fichero `postcss.config` separado.
+
 5. **Producción rápida**
    ```bash
    ./start-app.sh   # Linux/macOS

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "latest",
     "react-dom": "latest",
     "tailwindcss": "latest",
-    "zod": "latest"
+    "zod": "latest",
+    "@tailwindcss/postcss": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",
@@ -29,7 +30,6 @@
     "@types/react-dom": "latest",
     "eslint": "latest",
     "eslint-config-next": "latest",
-    "@tailwindcss/postcss": "latest",
     "@types/papaparse": "latest",
     "prisma": "latest",
     "tsx": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@prisma/client':
         specifier: latest
         version: 6.15.0(prisma@6.15.0(typescript@5.9.2))(typescript@5.9.2)
+      '@tailwindcss/postcss':
+        specifier: latest
+        version: 4.1.12
       autoprefixer:
         specifier: latest
         version: 10.4.21(postcss@8.5.6)
@@ -39,9 +42,6 @@ importers:
         specifier: latest
         version: 4.1.5
     devDependencies:
-      '@tailwindcss/postcss':
-        specifier: latest
-        version: 4.1.12
       '@types/node':
         specifier: latest
         version: 24.3.0

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Summary
- remove custom `postcss.config.mjs` so Next.js can supply its default Tailwind + Autoprefixer setup
- document default PostCSS setup and keep Tailwind PostCSS plugin as a runtime dependency

## Testing
- `pnpm install`
- `pnpm db:push` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ed6604c8328b3647f7f58860339