### PR TITLE
fix: handle missing database at startup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,15 @@ import { prisma } from "@/lib/db"
 import Link from "next/link"
 
 export default async function Page() {
-  const count = await prisma.product.count()
-  const latest = await prisma.product.findMany({ orderBy: { createdAt: 'desc' }, take: 5 })
+  let count = 0
+  let latest: { id: string; title: string; platform: string | null; source: string | null }[] = []
+
+  try {
+    count = await prisma.product.count()
+    latest = await prisma.product.findMany({ orderBy: { createdAt: 'desc' }, take: 5 })
+  } catch (err) {
+    console.error('Fallo al acceder a la base de datos', err)
+  }
 
   return (
     <main>

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -12,7 +12,12 @@ function Field({ label, children }: any) {
 
 export default async function ProductDetail({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const product = await prisma.product.findUnique({ where: { id }, include: { analysis: true } })
+  let product: any = null
+  try {
+    product = await prisma.product.findUnique({ where: { id }, include: { analysis: true } })
+  } catch (err) {
+    console.error('Fallo al acceder a la base de datos', err)
+  }
   if (!product) return <div>Producto no encontrado.</div>
   const productId = product.id
 

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -3,10 +3,15 @@ import Link from "next/link"
 import ScoreBadge from "@/components/ScoreBadge"
 
 export default async function Products() {
-  const products = await prisma.product.findMany({
-    orderBy: { createdAt: 'desc' },
-    include: { analysis: true }
-  })
+  let products: { id: string; title: string; platform: string | null; source: string | null; analysis: any }[] = []
+  try {
+    products = await prisma.product.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: { analysis: true }
+    })
+  } catch (err) {
+    console.error('Fallo al acceder a la base de datos', err)
+  }
 
   return (
     <main>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,12 @@
 import { PrismaClient, type Prisma } from '@prisma/client'
+import path from 'path'
+
+// Ensure there's always a DATABASE_URL so the app can run without extra setup
+if (!process.env.DATABASE_URL) {
+  const dbPath = path.join(process.cwd(), 'dev.db')
+  process.env.DATABASE_URL = `file:${dbPath}`
+}
+
 const globalForPrisma = globalThis as unknown as { prisma: PrismaClient }
 
 const logOptions: Prisma.LogLevel[] =


### PR DESCRIPTION
## Summary
- provide default SQLite path when DATABASE_URL is missing
- guard Prisma queries so pages render even without a database

## Testing
- `npm run lint`
- `npm run build`
- `npm run start`


------
https://chatgpt.com/codex/tasks/task_e_68b844cddbac8328a411ab36c4e42c33