### PR TITLE
feat(ui): add colorful layout and emojis

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,5 @@
 }
 
 body {
-  background-color: #17181A;
-  color: #ffffff;
+  @apply text-white bg-gradient-to-br from-slate-900 via-gray-900 to-black;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,19 +9,27 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="es">
-      <body className="min-h-screen">
+      <body className="min-h-screen bg-gradient-to-br from-slate-900 via-gray-900 to-black text-white">
         <div className="mx-auto max-w-6xl px-6 py-6">
           <nav className="flex items-center justify-between mb-6">
-            <div className="text-xl font-semibold">🧭 Trend Forge</div>
+            <div className="flex items-center gap-2 text-2xl font-bold text-teal-400">
+              🧭 Trend Forge
+            </div>
             <div className="flex gap-4 text-sm">
-              <Link href="/">Dashboard</Link>
-              <Link href="/products">Productos</Link>
-              <Link href="/sources">Importar</Link>
+              <Link className="flex items-center gap-1 hover:text-teal-300" href="/">
+                <span>🏠</span> Dashboard
+              </Link>
+              <Link className="flex items-center gap-1 hover:text-teal-300" href="/products">
+                <span>📦</span> Productos
+              </Link>
+              <Link className="flex items-center gap-1 hover:text-teal-300" href="/sources">
+                <span>📥</span> Importar
+              </Link>
             </div>
           </nav>
           {children}
-          <footer className="mt-10 text-xs text-gray-400">
-            Hecho con Next.js + Prisma · Diseño sobrio y útil · © {new Date().getFullYear()}
+          <footer className="mt-10 text-xs text-gray-400 text-center">
+            Hecho con Next.js + Prisma · Diseño colorido y útil · © {new Date().getFullYear()}
           </footer>
         </div>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,30 +14,51 @@ export default async function Page() {
 
   return (
     <main>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="rounded-2xl border border-neutral-800 p-4 shadow-soft">
-          <div className="text-gray-400 text-sm">Productos</div>
-          <div className="text-3xl font-semibold mt-2">{count}</div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <div className="rounded-2xl border border-teal-500/40 bg-slate-800/40 p-4 shadow-soft">
+          <div className="flex items-center gap-1 text-sm text-teal-400">
+            <span>📦</span> Productos
+          </div>
+          <div className="mt-2 text-3xl font-semibold text-white">{count}</div>
         </div>
-        <div className="rounded-2xl border border-neutral-800 p-4 shadow-soft">
-          <div className="text-gray-400 text-sm">Integraciones</div>
-          <div className="text-3xl font-semibold mt-2">OpenAI ✅ · CSV ✅</div>
+        <div className="rounded-2xl border border-purple-500/40 bg-slate-800/40 p-4 shadow-soft">
+          <div className="flex items-center gap-1 text-sm text-purple-400">
+            <span>🧩</span> Integraciones
+          </div>
+          <div className="mt-2 text-3xl font-semibold">OpenAI ✅ · CSV ✅</div>
         </div>
-        <div className="rounded-2xl border border-neutral-800 p-4 shadow-soft">
-          <div className="text-gray-400 text-sm">Siguiente</div>
-          <div className="mt-2 text-sm">Añade productos en <Link className="underline" href="/sources">Importar</Link> y analízalos con IA.</div>
+        <div className="rounded-2xl border border-indigo-500/40 bg-slate-800/40 p-4 shadow-soft">
+          <div className="flex items-center gap-1 text-sm text-indigo-400">
+            <span>⏭️</span> Siguiente
+          </div>
+          <div className="mt-2 text-sm">
+            Añade productos en
+            <Link className="text-indigo-300 underline" href="/sources">
+              {' '}Importar
+            </Link>{' '}y analízalos con IA.
+          </div>
         </div>
       </div>
 
-      <h2 className="mt-8 mb-2 font-semibold">Últimos añadidos</h2>
+      <h2 className="mt-8 mb-2 flex items-center gap-2 font-semibold text-teal-400">
+        🌟 Últimos añadidos
+      </h2>
       <div className="grid gap-3">
         {latest.map(p => (
-          <Link key={p.id} href={`/products/${p.id}`} className="rounded-xl border border-neutral-800 p-4 hover:bg-neutral-900 transition">
+          <Link
+            key={p.id}
+            href={`/products/${p.id}`}
+            className="rounded-xl border border-neutral-800 p-4 transition hover:bg-neutral-900"
+          >
             <div className="font-medium">{p.title}</div>
-            <div className="text-xs text-gray-400">{p.platform ?? '—'} · {p.source ?? 'manual'}</div>
+            <div className="text-xs text-gray-400">
+              {p.platform ?? '—'} · {p.source ?? 'manual'}
+            </div>
           </Link>
         ))}
-        {latest.length === 0 && <div className="text-sm text-gray-500">Sin productos todavía.</div>}
+        {latest.length === 0 && (
+          <div className="text-sm text-gray-500">😕 Sin productos todavía.</div>
+        )}
       </div>
     </main>
   )

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -15,19 +15,33 @@ export default async function Products() {
 
   return (
     <main>
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold mb-2">Productos</h1>
-        <Link className="text-sm underline" href="/sources">+ Importar</Link>
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="flex items-center gap-2 text-xl font-semibold text-teal-400">
+          📦 Productos
+        </h1>
+        <Link className="text-sm text-indigo-300 underline" href="/sources">
+          + Importar
+        </Link>
       </div>
       <div className="grid gap-3">
         {products.map(p => (
-          <Link key={p.id} href={`/products/${p.id}`} className="rounded-xl border border-neutral-800 p-4 hover:bg-neutral-900 transition">
+          <Link
+            key={p.id}
+            href={`/products/${p.id}`}
+            className="rounded-xl border border-neutral-800 p-4 transition hover:bg-neutral-900"
+          >
             <div className="font-medium">{p.title}</div>
-            <div className="text-xs text-gray-400">{p.platform ?? '—'} · {p.source ?? 'manual'}</div>
-            <div className="mt-2"><ScoreBadge score={p.analysis?.score ?? null} /></div>
+            <div className="text-xs text-gray-400">
+              {p.platform ?? '—'} · {p.source ?? 'manual'}
+            </div>
+            <div className="mt-2">
+              <ScoreBadge score={p.analysis?.score ?? null} />
+            </div>
           </Link>
         ))}
-        {products.length === 0 && <div className="text-sm text-gray-500">Sin productos todavía.</div>}
+        {products.length === 0 && (
+          <div className="text-sm text-gray-500">😕 Sin productos todavía.</div>
+        )}
       </div>
     </main>
   )

--- a/src/app/sources/page.tsx
+++ b/src/app/sources/page.tsx
@@ -3,8 +3,10 @@ import CSVImporter from "@/components/CSVImporter"
 export default function Sources() {
   return (
     <main>
-      <h1 className="text-xl font-semibold mb-2">Importar datos</h1>
-      <p className="text-sm text-gray-400 mb-4">
+      <h1 className="mb-2 flex items-center gap-2 text-xl font-semibold text-teal-400">
+        📥 Importar datos
+      </h1>
+      <p className="mb-4 text-sm text-gray-300">
         Carga CSV/JSON desde PiPiADS, Dropispy, AdSpy, TikTok, etc. También puedes mapear columnas personalizadas.
       </p>
       <CSVImporter />


### PR DESCRIPTION
## Summary
- refresh layout with gradient background and emoji navigation
- enhance dashboard and pages with colorful cards and headings
- brighten import page and product list with icons and color accents

## Testing
- `pnpm lint`
- `pnpm build` *(fails: The table `main.Product` does not exist in the current database)*

------
https://chatgpt.com/codex/tasks/task_e_68b84a04d140832889ec5b6d6f4f52d2